### PR TITLE
Correct Deloitte URL search param and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@
 
 Crowdsourced list of Canadian tech companies that are hiring interns for Summer 2023 that are interested in tech, SWE, and related fields. Never too early to get started in your search! Thanks to [elaine-zheng](https://github.com/elaine-zheng/summer2020internships) who made a similar document for the US for formatting inspiration.
 
-⚡️ Application openings are based on previous years information and may not apply to this years applications.
+⚡️ Application openings are based on previous years information and may not apply to this year's applications.
 
 To contribute:
  1. Fork repository
  2. Edit README.md
  3. Open a pull request!
 
-# ⏰ Applications Open Now 
+ # ⏰ Applications Open Now 
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
  |  [Amazon](https://www.amazon.jobs/zh/jobs/2114265/software-development-engineer-intern-2023-canada) |  Toronto, Vancouver, Victoria | Rolling Applications | No Set Application Deadline |
  | [Microsoft](https://careers.microsoft.com/students/us/en/job/1368428/Software-Engineering-Intern-Opportunities-for-University-Students-Canada) | Vancouver |  | No Set Application Deadline |
  | [Explore Microsoft](https://careers.microsoft.com/students/us/en/job/1368428/Explore-Microsoft-Intern-Opportunities-for-University-Students) | Vancouver |  | Must be freshman (class of 2026) or sophomore (class of 2025) |
  | [Konrad](https://boards.greenhouse.io/konradgroup/jobs/5268040003) | Toronto |  | No Set Application Deadline |
-|  [Google](https://careers.google.com/jobs/results/131850330833855174-software-developer-intern-bs-summer-2023/?distance=50&employment_type=INTERN) | Waterloo, Toronto, Montreal | Rolling Applications | |
+ |  [Google](https://careers.google.com/jobs/results/131850330833855174-software-developer-intern-bs-summer-2023/?distance=50&employment_type=INTERN) | Waterloo, Toronto, Montreal | Rolling Applications | |
  | [Google STEP](https://careers.google.com/jobs/results/112578365900104390-step-intern-summer-2023/?utm_campaign=google_jobs_apply&utm_medium=organic&utm_source=google_jobs_apply) | Waterloo, Montreal, Toronto | Before October 31, 2022 | Must be First or second-year Bachelor's student in Canada |
  | [HubSpot](https://boards.greenhouse.io/embed/job_app?token=3658637&gh_src=240b46771&s=LinkedIn&source=LinkedIn) | Ontario (Remote) | | Must be available to work full time from June - August 2023 to apply |
  | [Dropbox](https://www.dropbox.com/jobs/listing/4380645?gh_src=aonhf1) | Toronto (Remote) | | Flexible start dates, minimum 12 weeks | 
@@ -33,17 +33,16 @@ To contribute:
  | [Nasdaq](https://nasdaq.wd1.myworkdayjobs.com/en-US/US_External_Career_Site/job/Software-Engineer-ing-Intern---US---Canada-2023-Internship_R0011592) | Toronto | | No Set Application Deadline. Also, you must be a rising senior. |  
  |  [Autodesk](https://autodesk.wd1.myworkdayjobs.com/fr-FR/uni/details/Stagiaire-du-dveloppement-logiciel--mai--aot-2023----Intern--Software-Development--May-Aug-2023-_22WD63823?q=canada) |  Toronto, Montreal | Rolling Applications | Montreal positions are primarily for media products |
  
-
-# 🌻 Applications Open September 
+ # 🌻 Applications Open September 
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
  | [Capital One](https://www.capitalonecareers.ca/search-jobs) |  Toronto |  | Click on categories and select University  |
  |  [CIBC]( https://cibc.wd3.myworkdayjobs.com/campus) |  Toronto |    |   |
-  |  [IBM](https://ibm.biz/IBMinternships) |  Across Canada (Toronto, Markham, Ottawa, Fredricton,...) | Rolling Applications | No Set Application Deadline - Starting in Fall, Continuing Through the Spring Season  |
-|  [Mark43](https://www.mark43.com/departments/engineering/)  | Toronto |   | |
-|  [Mastercard](https://mastercard.wd1.myworkdayjobs.com/CorporateCareers/job/Vancouver-Canada/Software-Development-Engineer-Intern--Summer-2021_R-113650-1) |  Vancouver |   |  |
+ |  [IBM](https://ibm.biz/IBMinternships) |  Across Canada (Toronto, Markham, Ottawa, Fredricton,...) | Rolling Applications | No Set Application Deadline - Starting in Fall, Continuing Through the Spring Season  |
+ |  [Mark43](https://www.mark43.com/departments/engineering/)  | Toronto |   | |
+ |  [Mastercard](https://mastercard.wd1.myworkdayjobs.com/CorporateCareers/job/Vancouver-Canada/Software-Development-Engineer-Intern--Summer-2021_R-113650-1) |  Vancouver |   |  |
  |  [Microsoft](https://careers.microsoft.com/students/us/en/job/1115401/Software-Engineer-Intern-Opportunities%E2%80%AF%E2%80%AF) | Vancouver, Toronto |  
-|  [OTPP](https://otppb.wd3.myworkdayjobs.com/OntarioTeachers_Careers) |  Toronto |   |   |
+ |  [OTPP](https://otppb.wd3.myworkdayjobs.com/OntarioTeachers_Careers) |  Toronto |   |   |
  |  [Publicis sapient](https://sapient.avature.net/pscampus) | Toronto |  | |
  |  [RBC](https://jobs.rbc.com/ca/en/featuredopportunities/student-early-talent-jobs) |  Toronto |   |  Filter on summer to check open positions  | 
  |  [Splunk](https://jobs.jobvite.com/careers/splunk/job/oeaOdfw9/apply?__jvst=Job%20Board&__jvsd=LinkedIn) | Toronto |  | |
@@ -56,7 +55,7 @@ To contribute:
  # 🍂 Applications Open November 
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
-  |  [Affirm](https://boards.greenhouse.io/affirm/jobs/4650435003?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic) | Remote Canada |  | 	No Set Application Deadline |
+ |  [Affirm](https://boards.greenhouse.io/affirm/jobs/4650435003?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic) | Remote Canada |  | 	No Set Application Deadline |
  |  [Coveo](https://www.coveo.com/en/company/careers) |  Montreal, Quebec City |  |  |
  |  [Salesforce](https://salesforce.wd1.myworkdayjobs.com/Futureforce_Internships/5/refreshFacet/318c8bb6f553100021d223d9780d30be?d=cta-summer-view-sjb-1) |  Toronto, Vancouver |  | 	No Set Application Deadline |
 
@@ -64,32 +63,32 @@ To contribute:
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
  |  [BMO](https://bmo.wd3.myworkdayjobs.com/External/5/refreshFacet/318c8bb6f553100021d223d9780d30be) |  Toronto |  | Under Technology Early Talent |
- |  [Deloitte](https://careers.deloitte.ca/search/?createNewAlert=false&q=Summer+2022) |  Across Canada (Toronto, Montreal, Ottawa, ...) | Now - Mid January | Search for Summer 2023 |
+ |  [Deloitte](https://careers.deloitte.ca/search/?createNewAlert=false&q=Summer+2023) |  Across Canada (Toronto, Montreal, Ottawa, ...) | Now - Mid January | Search for Summer 2023 |
  |  [Nvidia](https://nvidia.wd5.myworkdayjobs.com/NVIDIAExternalCareerSite/3/refreshFacet/318c8bb6f553100021d223d9780d30be) |  Toronto |  |  |
  |  [Square](https://careers.squareup.com/ca/en/university) |  Kitchener |  |   |
  |  [Twilio](https://boards.greenhouse.io/twilio/jobs/3424707) |  Toronto, Vancouver |  |  |
  |  [Unity]( https://careers.unity.com/university) |  Montreal | |   |
  
-  # ❄️ Applications Open January 
+ # ❄️ Applications Open January 
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
  |  [Bolt](https://www.bolt.com/careers/) |  Toronto |   |   |
-  |  [Genetec](https://apply.workable.com/genetec-inc/?lng=en) | Montreal | January - March 2022 | Actively looking for Software Developers & Software Testers |
-  |  [Geotab](https://careers.geotab.com/jobs/) |  Toronto |  |  Data Science, Web Development and Software Engineering Available |
+ |  [Genetec](https://apply.workable.com/genetec-inc/?lng=en) | Montreal | January - March 2022 | Actively looking for Software Developers & Software Testers |
+ |  [Geotab](https://careers.geotab.com/jobs/) |  Toronto |  |  Data Science, Web Development and Software Engineering Available |
  |  [Intact Insurance](https://careers.intact.ca/ca/en/c/students-jobs) |  Toronto |  |   |
-  |  [Pagerduty](https://jobs.lever.co/pagerduty?commitment=Intern%2FCAP) |  Toronto |  |   |
+ |  [Pagerduty](https://jobs.lever.co/pagerduty?commitment=Intern%2FCAP) |  Toronto |  |   |
  |  [Shopify](https://www.shopify.ca/careers/search?specialties%5B%5D=interns&keywords=&sort=specialty_asc) |  Toronto, Ottawa |  |  |
-  |  [Zynga](https://www.zynga.com/job-listing-category/internships-new-grads/) |  Toronto |  |  |
+ |  [Zynga](https://www.zynga.com/job-listing-category/internships-new-grads/) |  Toronto |  |  |
 
  # 🏔️ Applications Open February 
  | Name  |  Location |  Application Period |  Notes |
  |---|---|---|---|
-  |  [Aviva](https://careers.avivacanada.com/career-levels/starting-your-career) |  Toronto, Montreal |  |  Closes Mid-March |
-   |  [Interac](https://interac.applytojob.com/apply) |  Toronto |    |  Closes Mid-February | |
+ |  [Aviva](https://careers.avivacanada.com/career-levels/starting-your-career) |  Toronto, Montreal |  |  Closes Mid-March |
+ |  [Interac](https://interac.applytojob.com/apply) |  Toronto |    |  Closes Mid-February | |
  |  [Loblaw Digital](https://jobs.lever.co/loblawdigital) |  Toronto | |   |
  |  [NanoLeaf](https://www.indeedjobs.com/nanoleaf/jobs) |  Toronto |   |  Hardware and Software Internships |
  |  [State Street](https://statestreet.wd1.myworkdayjobs.com/Global/1/refreshFacet/318c8bb6f553100021d223d9780d30be) |  Toronto | |  Closes Mid-February |
-  |  [Telus Digital](https://telus.taleo.net/careersection/10000/jobsearch.ftl?f=null&a=null&multiline=true&ignoreSavedQuery?linktype=subnav#) |  Toronto, Vancouver, Edmonton |    |   |
+ |  [Telus Digital](https://telus.taleo.net/careersection/10000/jobsearch.ftl?f=null&a=null&multiline=true&ignoreSavedQuery?linktype=subnav#) |  Toronto, Vancouver, Edmonton |    |   |
  |  [Vena Solutions](https://careers.venasolutions.com/job-board/) |  Toronto |   |  Closes Mid-March |
  |  [Wish](https://jobs.lever.co/wish?department=University&team=University&location=Toronto%2C%20Canada) |  Toronto | |   |
  |  [WealthSimple](https://jobs.lever.co/wealthsimple?commitment=Intern) |  Toronto |   |   |


### PR DESCRIPTION
- Correct the Deloitte search to `Summer-2023` (instead of `Summer-2022`)
- Consistent markdown spacing/"formatting"
- Small typofix, "this years" -> "this year's"

Not sure about the "formatting" changes which are not necessary and may be undesired, I would be happy to remove those (while keeping the two typofixes) if preferred :)